### PR TITLE
Fix the bug that only clips 4 faces' coordinates

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -386,7 +386,7 @@ def scale_coords(img1_shape, coords, img0_shape, ratio_pad=None, kpt_label=False
         coords[:, [1, 3]] -= pad[1]  # y padding
         coords[:, [0, 2]] /= gain
         coords[:, [1, 3]] /= gain
-        clip_coords(coords[0:4], img0_shape)
+        clip_coords(coords[:, 0:4], img0_shape)
         #coords[:, 0:4] = coords[:, 0:4].round()
     else:
         coords[:, 0::step] -= pad[0]  # x padding


### PR DESCRIPTION
- `coords[0:4]` retrieves only the first four face coordinates, so only first four face coordinates are clipped
- This can be fixed by replacing `coords[0:4]` with `coords[:, 0:4]` or `coords`