### PR TITLE
Fix loss gain datatype to support pytorch 1.13.1

### DIFF
--- a/utils/loss.py
+++ b/utils/loss.py
@@ -207,9 +207,9 @@ class ComputeLoss:
         na, nt = self.na, targets.shape[0]  # number of anchors, targets
         tcls, tbox, tkpt, indices, anch = [], [], [], [], []
         if self.kpt_label:
-            gain = torch.ones(self.kpt_label*2+7, device=targets.device)  # normalized to gridspace gain
+            gain = torch.ones(self.kpt_label*2+7, device=targets.device).long()  # normalized to gridspace gain
         else:
-            gain = torch.ones(7, device=targets.device)  # normalized to gridspace gain
+            gain = torch.ones(7, device=targets.device).long()  # normalized to gridspace gain
         ai = torch.arange(na, device=targets.device).float().view(na, 1).repeat(1, nt)  # same as .repeat_interleave(nt)
         targets = torch.cat((targets.repeat(na, 1, 1), ai[:, :, None]), 2)  # append anchor indices
 


### PR DESCRIPTION
This fixes an exception that occurs in newer pytorch versions during loss calculation:

```python
Traceback (most recent call last):
  File "F:\git\yolov7-face\train.py", line 562, in <module>
    train(hyp, opt, device, tb_writer)
  File "F:\git\yolov7-face\train.py", line 318, in train
    loss, loss_items = compute_loss(pred, targets.to(device))  # loss scaled by batch_size
  File "F:\git\yolov7-face\utils\loss.py", line 147, in __call__
    tcls, tbox, tkpt, indices, anchors = self.build_targets(p, targets)  # targets
  File "F:\git\yolov7-face\utils\loss.py", line 259, in build_targets
    indices.append((b, a, gj.clamp_(0, gain[3] - 1), gi.clamp_(0, gain[2] - 1)))  # image, anchor, grid indices
RuntimeError: result type Float can't be cast to the desired output type __int64
```

Also in yolov5 this was already mentioned: https://github.com/ultralytics/yolov5/issues/8405