### PR TITLE
Fix bug in `forward` method when model is in eval mode

### DIFF
--- a/models/yolo.py
+++ b/models/yolo.py
@@ -272,8 +272,8 @@ class IKeypoint(nn.Module):
 
             bs, _, ny, nx = x[i].shape  # x(bs,255,20,20) to x(bs,3,20,20,85)
             x[i] = x[i].view(bs, self.na, self.no, ny, nx).permute(0, 1, 3, 4, 2).contiguous()
-            x_det = x[i][..., :6]
-            x_kpt = x[i][..., 6:]
+            x_det = x[i][..., :6].clone().detach()
+            x_kpt = x[i][..., 6:].clone().detach()
 
             if not self.training:  # inference
                 if self.grid[i].shape[2:4] != x[i].shape[2:4]:


### PR DESCRIPTION
I've noticed that the keypoint validation error the model reports is orders of magnitude different from the training error, and doesn't really change over time.

I believe this is due to a pass-by-reference bug, which changes the predictions made in `eval` mode compared to `train`: In `eval` mode, the `IKeypoint.forward` method runs through some extra steps. Specifically, we reassign a slice of the original output to new variables `x_kpt` and `x_det`, but since we're passing by reference the subsequent code changes the original outputs ([lines 293-295](https://github.com/derronqi/yolov7-face/pull/55/files#diff-2cd118cbb69c9ca7b5544f4187b11335fc3addbaf2c3c5bb45435cac648c957bR293-R295)) . Fixing this by using .clone.detach().